### PR TITLE
Fix integer underflow bug in section.rs

### DIFF
--- a/intuitive/src/components/section.rs
+++ b/intuitive/src/components/section.rs
@@ -66,11 +66,12 @@ impl Element for Frozen {
   fn on_mouse(&self, rect: Rect, event: MouseEvent) {
     self.on_mouse.handle_or(event, |event| {
       self.content.on_mouse(
+        // Based on Block impl: https://docs.rs/tui/0.19.0/src/tui/widgets/block.rs.html#121
         Rect {
-          x: rect.x + 1,
-          y: rect.y - 1,
-          width: rect.width - 1,
-          height: rect.height - 1,
+          x: rect.x.saturating_add(1),
+          y: rect.y.saturating_add(1),
+          width: rect.width.saturating_sub(2),
+          height: rect.height.saturating_sub(2)
         },
         event,
       );


### PR DESCRIPTION
This would cause watch.rs to crash when build using debug mode. Considering that integer underflow is a problem in release mode, I used saturating_sub / saturating_add to avoid this problem, and included a link to the relevant source code.

On an another note, I myself am also building a TUI for my own application, and have been flowing moving towards this exact style. I'd like to contribute a few of the widgets I've built - infinitely scrolling lists, text-widgets with selection, copy/paste/cut, backwards / forwards deletion. I've also implemented additional scroll features based on keyboard input.

I'd also be interested in a focus-grabbing system for widgets (so that all input goes by default to a text entry widget, for example, and commands "bubble" up the stack) - I've implemented a basic version of this, but a more powerful version would allow assigning a deeply nested widget focus by default.